### PR TITLE
Split Display layout into own component, updated types, navigation+bugfixes

### DIFF
--- a/app/display/docs.ts
+++ b/app/display/docs.ts
@@ -1,4 +1,9 @@
-export type Info = { title: string; description: string; key: string; codesample: string };
+export type Info = {
+  title: string;
+  description: string;
+  key: string;
+  codesample: string;
+};
 const data: Info[] = [
   {
     title: " display.init() - None",
@@ -49,9 +54,10 @@ const data: Info[] = [
     codesample: "display.Info()",
   },
 ];
-const description = [
-  'pygame.display is a module that allows you to control the display window and screen'
-]
-
+const description = {
+  title: "pygame display Description",
+  description:
+    "pygame.display is a module that allows you to control the display window and screen",
+};
 
 export { data, description };

--- a/app/display/page.tsx
+++ b/app/display/page.tsx
@@ -1,69 +1,15 @@
 import React from "react";
 import { data, description } from "./docs";
-import GettingStarted from "../../components/GettingStarted";
-import TextBox from "../../components/TextBox";
+import DocLayout from "../../components/DocLayout";
 
 const Display = () => {
   return (
-      <div className="mx-auto max-w-2xl p-6 mb-10">
-        <div className="text-center">
-          <h2 className="text-3xl font-extrabold text-amber-300">
-            pygame.display Methods
-          </h2>
-          <p className="mt-4 text-lg text-white">
-            A list of methods available for use with the pygame.display class.
-          </p>
-        </div>
-
-        <div className="mt-10">
-          <ul className="divide-y divide-gray-200">
-            {data.map((method) => (
-              <div key={method.key}>
-                <li className="py-4">
-                  <div className="flex items-center space-x-4">
-                    <div className="flex-shrink-0">
-                      <div className="flex items-center justify-center h-12 w-12 rounded-md bg-blue-500 text-white">
-                        <svg
-                          className="h-6 w-6"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M13 10V3L4 14h7v7l9-11h-7z"
-                          />
-                        </svg>
-                      </div>
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-lg font-medium text-amber-300 truncate">
-                        {method.title}
-                      </p>
-                      <p className="mt-1 text-lg text-gray-300 font-mono">
-                        <span className="text-bold text-lg text-amber-400">
-                          Description:{" "}
-                        </span>
-                        {method.description}
-                      </p>
-                    </div>
-                  </div>
-                  <GettingStarted code={method.codesample} />
-                </li>
-              </div>
-            ))}
-          </ul>
-        </div>
-        <div className="mt-10 p-4 pb-40 text-white font-mono">
-          <TextBox
-            title="PyGame Display Description"
-            description={description[0]}
-          />
-        </div>
-      </div>
+    <DocLayout
+      title="pygame.display Methods"
+      baseDescription="A list of methods available for use with the pygame.display class."
+      data={data}
+      description={description}
+    />
   );
 };
 

--- a/components/DocLayout.tsx
+++ b/components/DocLayout.tsx
@@ -1,32 +1,15 @@
 import React from "react";
 import GettingStarted from "./GettingStarted";
 import TextBox from "./TextBox";
+import { Info, Description, LayoutProps } from "../types";
 
-type Info = {
-  title: string;
-  description: string;
-  key: string;
-  codesample: string;
-};
-
-type Description = {
-  title: string;
-  description: string;
-}
-
-type Props = {
-  title: string;
-  baseDescription: string;
-  data: Info[];
-  description: Description;
-};
 
 const DocLayout = ({
   title,
   baseDescription,
   data,
   description,
-}: Props) => {
+}: LayoutProps) => {
   return (
     <div className="mx-auto max-w-2xl p-6 mb-10">
       <div className="text-center">

--- a/components/DocLayout.tsx
+++ b/components/DocLayout.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import GettingStarted from "./GettingStarted";
+import TextBox from "./TextBox";
+
+type Info = {
+  title: string;
+  description: string;
+  key: string;
+  codesample: string;
+};
+
+type Description = {
+  title: string;
+  description: string;
+}
+
+type Props = {
+  title: string;
+  baseDescription: string;
+  data: Info[];
+  description: Description;
+};
+
+const DocLayout = ({
+  title,
+  baseDescription,
+  data,
+  description,
+}: Props) => {
+  return (
+    <div className="mx-auto max-w-2xl p-6 mb-10">
+      <div className="text-center">
+        <h2 className="text-3xl font-extrabold text-amber-300">{title}</h2>
+        <p className="mt-4 text-lg text-white">{baseDescription}</p>
+      </div>
+      <div className="mt-10">
+        <ul className="divide-y divide-gray-200">
+          {data.map((method) => (
+            <div key={method.key}>
+              <li className="py-4">
+                <div className="flex items-center space-x-4">
+                  <div className="flex-shrink-0">
+                    <div className="flex items-center justify-center h-12 w-12 rounded-md bg-blue-500 text-white">
+                      <svg
+                        className="h-6 w-6"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M13 10V3L4 14h7v7l9-11h-7z"
+                        />
+                      </svg>
+                    </div>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-lg font-medium text-amber-300 truncate">
+                      {method.title}
+                    </p>
+                    <p className="mt-1 text-lg text-gray-300 font-mono">
+                      <span className="text-bold text-lg text-amber-400">
+                        Description:{" "}
+                      </span>
+                      {method.description}
+                    </p>
+                  </div>
+                </div>
+                <GettingStarted code={method.codesample} />
+              </li>
+            </div>
+          ))}
+        </ul>
+      </div>
+      <div className="mt-10 p-4 pb-40 text-white font-mono">
+        <TextBox
+          title={description.title}
+          description={description.description}
+        />
+      </div>
+    </div>
+  );
+};
+export default DocLayout;

--- a/components/navbar.jsx
+++ b/components/navbar.jsx
@@ -30,7 +30,7 @@ const Navbar = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between h-16">
           <div className="flex-shrink-0 flex items-center">
-            <a href="/">
+            <Link href="/">
               <Image
                 className="block h-10 w-auto"
                 src="https://cdn-icons-png.flaticon.com/512/2570/2570575.png"
@@ -38,7 +38,7 @@ const Navbar = () => {
                 width={50}
                 height={50}
               />
-            </a>
+            </Link>
           </div>
           <div className="flex items-center lg:hidden">
             <button
@@ -56,12 +56,12 @@ const Navbar = () => {
             </button>
           </div>
           <div className="hidden lg:flex lg:items-center lg:justify-end lg:flex-1 font-mono">
-            <a
+            <Link
               href="/"
               className="whitespace-nowrap text-base font-medium text-gray-500 hover:text-white"
             >
               Home
-            </a>
+            </Link>
             <div className="relative ml-8">
               <button
                 onClick={() => setIsOpen(!isOpen)}
@@ -80,6 +80,7 @@ const Navbar = () => {
                       <Link
                         key={topic}
                         href={`/${topic.toLowerCase().replace(/\s+/g, "-")}`}
+                        onClick={() => setIsOpen(!isOpen)}
                       >
                         <span className="block px-4 py-2 text-sm text-white bg-gray-900 hover:bg-gray-800">
                           {topic}
@@ -92,18 +93,18 @@ const Navbar = () => {
             </div>
            
 
-            <a
+            <Link
               href="/donate"
               className="ml-8 whitespace-nowrap text-base font-medium text-gray-500 hover:text-white"
             >
               Donate
-            </a>
-            <a
+            </Link>
+            <Link
               href="/"
               className="ml-8 whitespace-nowrap text-base font-medium text-gray-500 hover:text-white"
             >
               Log in
-            </a>
+            </Link>
             <Link
               href="/signup"
               className="ml-4 whitespace-nowrap inline-flex items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700"
@@ -116,18 +117,18 @@ const Navbar = () => {
 
       <div className={isOpen ? "block lg:hidden" : "hidden"} id="mobile-menu">
         <div className="pt-2 pb-3 space-y-1">
-          <a
+          <Link
             href="/"
             className="block pl-3 pr-4 py-2 border-l-4 text-base font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-50"
           >
             Home
-          </a>
-          <a
+          </Link>
+          <Link
             href="/"
             className="block pl-3 pr-4 py-2 border-l-4 text-base font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-50"
           >
             Features
-          </a>
+          </Link>
 
           <Link
             href="/donate"
@@ -136,12 +137,12 @@ const Navbar = () => {
             Donate
           </Link>
 
-          <a
+          <Link
             href="/"
             className="block pl-3 pr-4 py-2 border-l-4 text-base font-medium text-gray-500 hover:text-gray-900 hover:bg-gray-50"
           >
             Log in
-          </a>
+          </Link>
         </div>
         <Link
           href="/signup"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     ".next/types/**/*.ts",
     "**/*.ts",
     "**/*.tsx",
-    "app/events/docs.js"
-, "components/PygameModal.jsx"  ],
+    "app/events/docs.js",
+    "components/PygameModal.jsx"
+  ],
   "exclude": ["node_modules"]
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,18 @@
+export type Info = {
+  title: string;
+  description: string;
+  key: string;
+  codesample: string;
+};
+
+export type Description = {
+  title: string;
+  description: string;
+};
+
+export type LayoutProps = {
+  title: string;
+  baseDescription: string;
+  data: Info[];
+  description: Description;
+};


### PR DESCRIPTION
Additions:
- Created component for Documentation Layout
- Created additional types within the Doc layout
- Added types into their own file to allow for type reuse

Updates:
- Updated description to include the title too
- Changed `a` in Navbar to `Link` to maintain the navigation system

Bug Fixes:
- Closes Navbar to close upon navigating

Needs to be fixed:
- Page not found breaks Navigation dropdown